### PR TITLE
Set audio mix options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,8 @@ Made SimpleCache singleton thread safe
 ## 1.0.3
 
 Support iOS
+
+## 1.0.4
+
+Android: gain audio focus when playing a video. Stop mixing audio from 
+  3rd party video/music players when a video is played.

--- a/android/src/main/java/com/lazyarts/vikram/cached_video_player/CachedVideoPlayerPlugin.java
+++ b/android/src/main/java/com/lazyarts/vikram/cached_video_player/CachedVideoPlayerPlugin.java
@@ -199,7 +199,7 @@ public class CachedVideoPlayerPlugin implements MethodCallHandler {
     private static void setAudioAttributes(SimpleExoPlayer exoPlayer) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
         exoPlayer.setAudioAttributes(
-            new AudioAttributes.Builder().setContentType(C.CONTENT_TYPE_MOVIE).build());
+           new AudioAttributes.Builder().setContentType(C.CONTENT_TYPE_MOVIE).build(), true);
       } else {
         exoPlayer.setAudioStreamType(C.STREAM_TYPE_MUSIC);
       }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -19,7 +19,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  cached_video_player: 1.0.3
+  cached_video_player:
+    path: ../
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cached_video_player
 description: A new flutter plugin that is virtually a clone of official video_player plugin except that it supports caching( Android and iOS)
-version: 1.0.3
+version: 1.0.4
 homepage: https://github.com/vikram25897/flutter_cached_video_player
 
 environment:


### PR DESCRIPTION
closes #19 
Stop mixing audio from 3rd party video/music players when a video is played.

`flutter pub publish --dry-run` 
```
Publishing cached_video_player 1.0.4 to https://pub.dartlang.org:

Package has 0 warnings.
```