### PR TITLE
Fix Flutter 3 warnings

### DIFF
--- a/lib/cached_video_player.dart
+++ b/lib/cached_video_player.dart
@@ -579,7 +579,7 @@ class _CachedVideoAppLifeCycleObserver extends Object
   final CachedVideoPlayerController _controller;
 
   void initialize() {
-    WidgetsBinding.instance?.addObserver(this);
+    WidgetsBinding.instance.addObserver(this);
   }
 
   @override
@@ -599,7 +599,7 @@ class _CachedVideoAppLifeCycleObserver extends Object
   }
 
   void dispose() {
-    WidgetsBinding.instance!.removeObserver(this);
+    WidgetsBinding.instance.removeObserver(this);
   }
 }
 


### PR DESCRIPTION
Flutter 3 throws warnings because some bindings are now non-nullable. This PR literally just removes two `?`.