### PR TITLE
Skip cache on iOS if formatHint is hls

### DIFF
--- a/ios/Classes/CachedVideoPlayerPlugin.m
+++ b/ios/Classes/CachedVideoPlayerPlugin.m
@@ -533,8 +533,12 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     return [self onPlayerSetup:player frameUpdater:frameUpdater];
   } else if (input.uri) {
     // player = [[CachedVideoPlayer alloc] initWithURL:[NSURL URLWithString:input.uri]
-    NSURL *proxyURL = [KTVHTTPCache proxyURLWithOriginalURL:[NSURL URLWithString:input.uri]];
-    player = [[CachedVideoPlayer alloc] initWithURL:proxyURL
+    NSURL *usedURL = [NSURL URLWithString:input.uri];
+    if(![input.formatHint isEqual: @"hls"]) {
+      usedURL = [KTVHTTPCache proxyURLWithOriginalURL:usedURL];
+    }
+
+    player = [[CachedVideoPlayer alloc] initWithURL:usedURL
                                     frameUpdater:frameUpdater
                                      httpHeaders:input.httpHeaders];
     return [self onPlayerSetup:player frameUpdater:frameUpdater];


### PR DESCRIPTION
- This doesn't quite fix #2, but it at least allows proper playback by skipping the cache.

To use this, just set `formatHint` to hls:

```dart
final controller = CachedVideoPlayerController.network(
  url,
  formatHint: VideoFormat.hls,
);
```

The proposed alternative (adding an additional option `useCache`) would be technically superior, but requires altering the pigeon channels, which might not be optimal since it might make updating to a new `video_player` version a bit harder.