### PR TITLE
Preserve headers when using KTVHTTPCache

### DIFF
--- a/ios/Classes/CachedVideoPlayerPlugin.m
+++ b/ios/Classes/CachedVideoPlayerPlugin.m
@@ -536,6 +536,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     NSURL *usedURL = [NSURL URLWithString:input.uri];
     if(![input.formatHint isEqual: @"hls"]) {
       usedURL = [KTVHTTPCache proxyURLWithOriginalURL:usedURL];
+      [KTVHTTPCache downloadSetAdditionalHeaders:input.httpHeaders];
     }
 
     player = [[CachedVideoPlayer alloc] initWithURL:usedURL


### PR DESCRIPTION
When the KTVHTTPCache is used the headers are lost.

With this small change headers are preserved.

You can test this functionality for example if you use passwords in the headers, without this change the password header is lost and the file is inaccessible.