### PR TITLE
Bump video_player_platform_interface for compatibility with other video_player plugins

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ flutter:
 
 dependencies:
   meta: ^1.7.0
-  video_player_platform_interface: ^5.1.2
+  video_player_platform_interface: ^6.0.1
 
   # The design on https://flutter.dev/go/federated-plugins was to leave
   # this constraint as "any". We cannot do it right now as it fails pub publish


### PR DESCRIPTION
When using `flutter_cached_video_player` in a project together with [video_player_macos](https://github.com/ollydixon/flutter_macos_video_player), this error is thrown on build:
```
Because every version of video_player_macos from git depends on video_player_platform_interface ^6.0.1 and every version of cached_video_player from git depends on video_player_platform_interface ^5.1.2, video_player_macos from git is incompatible with cached_video_player from git.
```

This PR fixes that issue by bumping `video_player_platform_interface` to version `^6.0.1`. I didn't find any compatibility problems.
