### PR TITLE
Make compatible with AGP 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,11 @@ project.getTasks().withType(JavaCompile){
 apply plugin: 'com.android.library'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+      namespace 'com.lazyarts.vikram.cached_video_player'
+    }
+
     compileSdkVersion 29
 
     defaultConfig {


### PR DESCRIPTION
- Adds a namespace to make it compatible with Android Gradle Plugin (AGP) 8
- Solution copied from the cloud_firestore package, so it's still backwards compatible with AGP <4.2