### PR TITLE
Revert "Bump video_player_platform_interface for compatibility with o…

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ flutter:
 
 dependencies:
   meta: ^1.7.0
-  video_player_platform_interface: ^6.0.1
+  video_player_platform_interface: ^5.1.2
 
   # The design on https://flutter.dev/go/federated-plugins was to leave
   # this constraint as "any". We cannot do it right now as it fails pub publish


### PR DESCRIPTION
Some time ago I reviewed a PR that added this, but this package isn't compatible with `video_player_platform_interface: ^6`. I didn't realize this at the time because everything compiled just fine, but I have to revert this for now because it breaks during runtime.

@ffactory-ofcl Could you please re-create your PR with the necessary changes to make this compatible?

For anyone reading this who only cares about build and doesn't use the package to actually play back videos (specifically: "don't call init()!"), then a simple dependency override in your pubspec.yaml will do.